### PR TITLE
fix(answer): alter column answer to description

### DIFF
--- a/migration/20231003011000_alter_table_answers.down.sql
+++ b/migration/20231003011000_alter_table_answers.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE answers
+RENAME COLUMN description to answer;

--- a/migration/20231003011000_alter_table_answers.up.sql
+++ b/migration/20231003011000_alter_table_answers.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE answers
+RENAME COLUMN answer to description;


### PR DESCRIPTION
add migration to rename column `answer` to `description` at table `answers`

fix: #59 