### PR TITLE
fix:migrate alter table questions and test_attempt

### DIFF
--- a/migration/20231012164843_change_table_questions.down.sql
+++ b/migration/20231012164843_change_table_questions.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE questions 
+MODIFY type VARCHAR(50) NOT NULL;
+ALTER TABLE questions
+MODIFY question VARCHAR(255) NOT NULL;
+ALTER TABLE questions
+DROP COLUMN url_video;
+ALTER TABLE questions
+DROP COLUMN section;

--- a/migration/20231012164843_change_table_questions.up.sql
+++ b/migration/20231012164843_change_table_questions.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE questions 
+MODIFY type VARCHAR(255);
+ALTER TABLE questions
+MODIFY question text;
+ALTER TABLE questions
+ADD url_video text AFTER description;
+ALTER TABLE questions
+ADD section VARCHAR(255) AFTER url_video;

--- a/migration/20231012170108_alter_testattempt.down.sql
+++ b/migration/20231012170108_alter_testattempt.down.sql
@@ -1,2 +1,10 @@
 ALTER TABLE test_attempt
 DROP COLUMN diagnosis;
+ALTER TABLE test_attempt
+DROP COLUMN ai_diagnosis;
+ALTER TABLE test_attempt
+DROP COLUMN ai_probability;
+ALTER TABLE test_attempt
+DROP COLUMN ai_accuracy;
+ALTER TABLE test_attempt
+DROP COLUMN status;

--- a/migration/20231012170108_alter_testattempt.down.sql
+++ b/migration/20231012170108_alter_testattempt.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE test_attempt
+DROP COLUMN diagnosis;

--- a/migration/20231012170108_alter_testattempt.up.sql
+++ b/migration/20231012170108_alter_testattempt.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE test_attempt
+ADD diagnosis text AFTER score;

--- a/migration/20231012170108_alter_testattempt.up.sql
+++ b/migration/20231012170108_alter_testattempt.up.sql
@@ -1,2 +1,10 @@
 ALTER TABLE test_attempt
 ADD diagnosis text AFTER score;
+ALTER TABLE test_attempt
+ADD ai_diagnosis FLOAT AFTER score;
+ALTER TABLE test_attempt
+ADD ai_probability FLOAT AFTER score;
+ALTER TABLE test_attempt
+ADD ai_accuracy FLOAT AFTER score;
+ALTER TABLE test_attempt
+ADD status VARCHAR(255) AFTER feedback;


### PR DESCRIPTION
table Questions:
- alter column `type` remove not null
- alter column `question` remove not null and change type to text
- add column `url_video` text
- add column `section` varchar(255)

table test_attept:
- add column `diagnosis` text
- add column `ai_diagnosis` text
- add column `ai_probability` float
- add column `ai_accuracy` float
- add column `status` varchar 255

Fix: #66 