### PR TITLE
fix(schedule): change mapping schedule response

### DIFF
--- a/features/schedule/data/model.go
+++ b/features/schedule/data/model.go
@@ -65,7 +65,7 @@ func CoreToData(core schedule.Core) Schedules {
 		TimeEnd:           core.TimeEnd,
 		CreatedAt:         core.CreatedAt,
 		UpdatedAt:         core.UpdatedAt,
-		DeletedAt:         &core.UpdatedAt,
+		DeletedAt:         core.DeletedAt,
 		User: Users{
 			ID:             core.User.ID,
 			Name:           core.User.Name,
@@ -87,7 +87,7 @@ func DataToCore(data Schedules) schedule.Core {
 		TimeEnd:           data.TimeEnd,
 		CreatedAt:         data.CreatedAt,
 		UpdatedAt:         data.UpdatedAt,
-		DeletedAt:         &data.UpdatedAt,
+		DeletedAt:         data.DeletedAt,
 		User: schedule.User{
 			ID:             data.User.ID,
 			Name:           data.User.Name,


### PR DESCRIPTION
Fix: #103 

```
func DataToCore(data Schedules) schedule.Core {
	return schedule.Core{
           ...
		UpdatedAt:         data.UpdatedAt,
		DeletedAt:         data.DeletedAt,
```

```
func CoreToData(core schedule.Core) Schedules {
	return Schedules{
		...
		UpdatedAt:         core.UpdatedAt,
		DeletedAt:          core.DeletedAt,
```