### PR TITLE
fix(auth): add name and role at login response

### DIFF
--- a/features/auth/data/query.go
+++ b/features/auth/data/query.go
@@ -35,29 +35,29 @@ func (repo *authQuery) CreateToken(id any, role string) (token string, err error
 }
 
 // GetUserByEmail implements auth.AuthDataInterface.
-func (repo *authQuery) GetUserByEmail(email string) (auth.UserCore, error) {
+func (repo *authQuery) GetUserByEmail(email string) (*auth.UserCore, error) {
 	var record auth.UserCore
-	tx := repo.db.Table("users").Select("id", "email", "password", "name", "role").Where("email = ?", email).Scan(&record)
+	tx := repo.db.Table("users").Select("id", "email", "password", "name", "role").Where("email = ? and deleted_at is null", email).Scan(&record)
 	if tx.Error != nil {
-		return auth.UserCore{}, helpers.CheckQueryErrorMessage(tx.Error)
+		return nil, helpers.CheckQueryErrorMessage(tx.Error)
 	}
 
 	if tx.RowsAffected == 0 {
-		return auth.UserCore{}, errors.New(config.DB_ERR_RECORD_NOT_FOUND)
+		return nil, errors.New(config.DB_ERR_RECORD_NOT_FOUND)
 	}
-	return record, nil
+	return &record, nil
 }
 
 // GetPatientByEmail implements auth.AuthDataInterface.
-func (repo *authQuery) GetPatientByEmail(email string) (auth.PatientCore, error) {
+func (repo *authQuery) GetPatientByEmail(email string) (*auth.PatientCore, error) {
 	var record auth.PatientCore
-	tx := repo.db.Table("patients").Select("id", "email", "password", "name", "phone").Where("email = ?", email).Scan(&record)
+	tx := repo.db.Table("patients").Select("id", "email", "password", "name", "phone").Where("email = ? and deleted_at is null", email).Scan(&record)
 	if tx.Error != nil {
-		return auth.PatientCore{}, helpers.CheckQueryErrorMessage(tx.Error)
+		return nil, helpers.CheckQueryErrorMessage(tx.Error)
 	}
 
 	if tx.RowsAffected == 0 {
-		return auth.PatientCore{}, errors.New(config.DB_ERR_RECORD_NOT_FOUND)
+		return nil, errors.New(config.DB_ERR_RECORD_NOT_FOUND)
 	}
-	return record, nil
+	return &record, nil
 }

--- a/features/auth/entity.go
+++ b/features/auth/entity.go
@@ -18,11 +18,11 @@ type PatientCore struct {
 
 type AuthDataInterface interface {
 	CreateToken(id any, role string) (token string, err error)
-	GetUserByEmail(email string) (UserCore, error)
-	GetPatientByEmail(email string) (PatientCore, error)
+	GetUserByEmail(email string) (*UserCore, error)
+	GetPatientByEmail(email string) (*PatientCore, error)
 }
 
 type AuthServiceInterface interface {
-	Login(email string, password string) (string, error)
-	LoginPatient(email string, password string) (string, error)
+	Login(email string, password string) (*UserCore, string, error)
+	LoginPatient(email string, password string) (*PatientCore, string, error)
 }

--- a/features/auth/handler/handler.go
+++ b/features/auth/handler/handler.go
@@ -25,7 +25,7 @@ func (handler *AuthHandler) LoginPatient(c echo.Context) error {
 		return c.JSON(httpCode, jsonResponse)
 	}
 
-	token, err := handler.authService.LoginPatient(authInput.Email, authInput.Password)
+	dataPatient, token, err := handler.authService.LoginPatient(authInput.Email, authInput.Password)
 	if err != nil {
 		jsonResponse, httpCode := helpers.WebResponseError(err, config.FEAT_AUTH_CODE)
 		return c.JSON(httpCode, jsonResponse)
@@ -33,6 +33,8 @@ func (handler *AuthHandler) LoginPatient(c echo.Context) error {
 
 	mapResponse, httpCode := helpers.WebResponseSuccess("[success] login", config.FEAT_AUTH_CODE, map[string]any{
 		"token": token,
+		"name":  &dataPatient.Name,
+		"role":  config.VAL_PatientAccess,
 	})
 	return c.JSON(httpCode, mapResponse)
 
@@ -46,7 +48,7 @@ func (handler *AuthHandler) Login(c echo.Context) error {
 		return c.JSON(httpCode, jsonResponse)
 	}
 
-	token, err := handler.authService.Login(authInput.Email, authInput.Password)
+	dataUser, token, err := handler.authService.Login(authInput.Email, authInput.Password)
 	if err != nil {
 		jsonResponse, httpCode := helpers.WebResponseError(err, config.FEAT_AUTH_CODE)
 		return c.JSON(httpCode, jsonResponse)
@@ -54,6 +56,8 @@ func (handler *AuthHandler) Login(c echo.Context) error {
 
 	mapResponse, httpCode := helpers.WebResponseSuccess("[success] login", config.FEAT_AUTH_CODE, map[string]any{
 		"token": token,
+		"name":  &dataUser.Name,
+		"role":  &dataUser.Role,
 	})
 	return c.JSON(httpCode, mapResponse)
 


### PR DESCRIPTION
Fix: #105 

```
{
    "data": {
        "name": "budi 2",
        "role": "patient",
        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemVkIjp0cnVlLCJleHAiOjE2OTk1MDc3NjQsInJvbGUiOiJwYXRpZW50IiwidXNlcklkIjoiMzhlODJkNjgtY2NlYi00MDYzLThjOTktY2U0ZTI2NzZmMjZkIn0.I82sL3viUubnbn3L_l2WEgrPcNJHp_-wljgtLy7BArc"
    },
    "messages": [
        "[success] login"
    ],
    "meta": {
        "code": "200-002-OK",
        "status": "success"
    }
}
```