### PR TITLE
feat: add pagination response and handle limit at patient list and schedule list

### DIFF
--- a/features/booking/entity.go
+++ b/features/booking/entity.go
@@ -44,16 +44,18 @@ type Service interface {
 	Create(data Core, role string) error
 	Update(id string, data Core, role string) error
 	Delete(id string, role string) error
-	GetAll(role string) ([]Core, error)
+	GetAll(role string, page int, perPage int) ([]Core, error)
 	GetByUserID(userID int, role string) ([]Core, error)
 	GetByPatientID(patientID string) ([]Core, error)
+	GetPagination(page int, perPage int) (map[string]any, error)
 }
 type Data interface {
 	Create(data Core) (bookingID *string, err error)
 	Update(id string, data Core) error
 	Delete(id string) error
-	GetAll() ([]Core, error)
+	GetAll(offset int, limit int) ([]Core, error)
 	GetByUserID(userID int) ([]Core, error)
 	GetByPatientID(patientID string) ([]Core, error)
 	GetByBookingID(bookingID string) (*Core, error)
+	CountByFilter() (int64, error)
 }

--- a/features/booking/handler/handler.go
+++ b/features/booking/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"strconv"
 
 	"github.com/dr-ariawan-s-project/api-drariawan/app/config"
@@ -102,12 +103,38 @@ func (bh *BookingHandler) GetAll() echo.HandlerFunc {
 			jsonResponse, httpCode := helpers.WebResponseError(err, config.FEAT_BOOKING_CODE)
 			return c.JSON(httpCode, jsonResponse)
 		}
-		res, err := bh.srv.GetAll(role)
+		qPage := c.QueryParam("page")
+		qLimit := c.QueryParam("limit")
+
+		var page, limit int
+		if qPage != "" {
+			var errPage error
+			page, errPage = strconv.Atoi(qPage)
+			if errPage != nil {
+				jsonResponse, httpCode := helpers.WebResponseError(errors.New(config.REQ_InvalidPageParam), config.FEAT_PATIENT_CODE)
+				return c.JSON(httpCode, jsonResponse)
+			}
+		}
+		if qLimit != "" {
+			var errLimit error
+			limit, errLimit = strconv.Atoi(qLimit)
+			if errLimit != nil {
+				jsonResponse, httpCode := helpers.WebResponseError(errors.New(config.REQ_InvalidLimitParam), config.FEAT_PATIENT_CODE)
+				return c.JSON(httpCode, jsonResponse)
+			}
+		}
+
+		res, err := bh.srv.GetAll(role, page, limit)
 		if err != nil {
 			jsonResponse, httpCode := helpers.WebResponseError(err, config.FEAT_BOOKING_CODE)
 			return c.JSON(httpCode, jsonResponse)
 		}
 		mapResponse, httpCode := helpers.WebResponseSuccess("[success] read data", config.FEAT_BOOKING_CODE, res)
+		//pagination
+		paginationRes, errPagination := bh.srv.GetPagination(page, limit)
+		if errPagination == nil {
+			mapResponse["pagination"] = paginationRes
+		}
 		return c.JSON(httpCode, mapResponse)
 
 	}

--- a/features/patient/data/query.go
+++ b/features/patient/data/query.go
@@ -115,7 +115,10 @@ func (repo *patientQuery) Select(search string, offset int, limit int) ([]patien
 		tx.Where("name like ? OR email LIKE ?", "%"+search+"%", "%"+search+"%")
 	}
 	tx.Where("deleted_at is null")
-	tx.Offset(offset).Limit(limit).Find(&patient)
+	if limit != 0 {
+		tx.Offset(offset).Limit(limit)
+	}
+	tx.Find(&patient)
 	if tx.Error != nil {
 		return nil, helpers.CheckQueryErrorMessage(tx.Error)
 	}

--- a/features/patient/service/logic.go
+++ b/features/patient/service/logic.go
@@ -30,6 +30,11 @@ func (service *patientService) GetPagination(search string, page int, perPage in
 		return helpers.Pagination{}, err
 	}
 	paginationRes := helpers.CountPagination(totalRows, page, perPage)
+	if perPage == 0 {
+		// di patient feature, jika limit tidak diinputkan maka tampilkan semua datanya.
+		paginationRes.Limit = 0
+		paginationRes.TotalPages = 1
+	}
 	return paginationRes, nil
 }
 
@@ -69,9 +74,9 @@ func (service *patientService) Delete(id string) error {
 
 // FindAll implements patient.PatientServiceInterface.
 func (service *patientService) FindAll(search string, page int, perPage int) ([]patient.Core, error) {
-	if perPage <= 0 {
-		perPage = 10
-	}
+	// if perPage <= 0 {
+	// 	perPage = 10
+	// }
 	if page <= 0 {
 		page = 1
 	}

--- a/features/questionaire/entity.go
+++ b/features/questionaire/entity.go
@@ -1,6 +1,10 @@
 package questionaire
 
-import "time"
+import (
+	"time"
+
+	"github.com/dr-ariawan-s-project/api-drariawan/utils/helpers"
+)
 
 type Core struct {
 	Id          uint
@@ -77,6 +81,7 @@ type QuestionaireDataInterface interface {
 	InsertAssesment(data CoreAttempt) error
 	CountAllQuestion() (int, error)
 	CountQuestionerAttempt() (int, error)
+	CountTestAttemptByFilter(status string) (int64, error)
 }
 
 type QuestionaireServiceInterface interface {
@@ -87,4 +92,5 @@ type QuestionaireServiceInterface interface {
 	GetAllAnswerByAttempt(idAttempt string, page int, perPage int) (dataAnswer []CoreAnswer, err error)
 	InsertAssesment(data CoreAttempt) error
 	CountQuestionerAttempt() (int, error)
+	GetPaginationTestAttempt(status string, page int, perPage int) (helpers.Pagination, error)
 }

--- a/features/questionaire/handler/handler.go
+++ b/features/questionaire/handler/handler.go
@@ -95,6 +95,11 @@ func (handler *QuestionaireHandler) GetAllTestAttempt(c echo.Context) error {
 
 	var attemptResponse = ListAttemptCoreToResponse(results)
 	mapResponse, httpCode := helpers.WebResponseSuccess("[success] read data", config.FEAT_QUESTIONAIRE_CODE, attemptResponse)
+	//pagination
+	paginationRes, errPagination := handler.questionaireService.GetPaginationTestAttempt(qStatus, page, limit)
+	if errPagination == nil {
+		mapResponse["pagination"] = paginationRes
+	}
 	return c.JSON(httpCode, mapResponse)
 }
 

--- a/features/questionaire/service/logic.go
+++ b/features/questionaire/service/logic.go
@@ -17,6 +17,17 @@ type questionaireService struct {
 	cfg              *config.AppConfig
 }
 
+// for pagination
+// GetPaginationTestAttempt implements questionaire.QuestionaireServiceInterface.
+func (service *questionaireService) GetPaginationTestAttempt(status string, page int, perPage int) (helpers.Pagination, error) {
+	totalRows, err := service.questionaireData.CountTestAttemptByFilter(status)
+	if err != nil {
+		return helpers.Pagination{}, err
+	}
+	paginationRes := helpers.CountPagination(totalRows, page, perPage)
+	return paginationRes, nil
+}
+
 func New(repo questionaire.QuestionaireDataInterface, patientServ patient.PatientServiceInterface, cfg *config.AppConfig) questionaire.QuestionaireServiceInterface {
 	return &questionaireService{
 		questionaireData: repo,

--- a/features/schedule/entity.go
+++ b/features/schedule/entity.go
@@ -43,11 +43,13 @@ type ScheduleService interface {
 	Create(data Core, role string) error
 	Update(id int, data Core, role string) error
 	Delete(id int, role string) error
-	GetAll(role string) ([]Core, error)
+	GetAll(role string, page int, perPage int) ([]Core, error)
+	GetPagination(page int, perPage int) (map[string]any, error)
 }
 type ScheduleData interface {
 	Create(data Core) error
 	Update(id int, data Core) error
 	Delete(id int) error
-	GetAll() ([]Core, error)
+	GetAll(offset int, limit int) ([]Core, error)
+	CountByFilter() (int64, error)
 }

--- a/features/schedule/service/logic.go
+++ b/features/schedule/service/logic.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dr-ariawan-s-project/api-drariawan/app/config"
 	"github.com/dr-ariawan-s-project/api-drariawan/features/schedule"
+	"github.com/dr-ariawan-s-project/api-drariawan/utils/helpers"
 	"github.com/dr-ariawan-s-project/api-drariawan/utils/validation"
 )
 
@@ -17,6 +18,32 @@ func New(sd schedule.ScheduleData) schedule.ScheduleService {
 	return &ScheduleService{
 		qry: sd,
 	}
+}
+
+// for pagination
+// GetPagination implements schedule.ScheduleService.
+func (ss *ScheduleService) GetPagination(page int, perPage int) (map[string]any, error) {
+	totalRows, err := ss.qry.CountByFilter()
+	response := map[string]any{
+		"page":          0,
+		"limit":         0,
+		"total_pages":   0,
+		"total_records": 0,
+	}
+	if err != nil {
+		return response, err
+	}
+	paginationRes := helpers.CountPagination(totalRows, page, perPage)
+	response["page"] = paginationRes.Page
+	response["limit"] = paginationRes.Limit
+	response["total_pages"] = paginationRes.TotalPages
+	if perPage == 0 {
+		// di schedule feature, jika limit tidak diinputkan maka tampilkan semua datanya.
+		response["limit"] = 0
+		response["total_pages"] = 1
+	}
+	response["total_records"] = paginationRes.TotalRecords
+	return response, nil
 }
 
 // Create implements schedule.ScheduleService.
@@ -72,13 +99,24 @@ func (ss *ScheduleService) Delete(id int, role string) error {
 }
 
 // GetAll implements schedule.ScheduleService.
-func (ss *ScheduleService) GetAll(role string) ([]schedule.Core, error) {
+func (ss *ScheduleService) GetAll(role string, page int, perPage int) ([]schedule.Core, error) {
 	// log.Println(strings.ToLower(role), config.VAL_SusterAccess)
 	if strings.ToLower(role) != config.VAL_SusterAccess && strings.ToLower(role) != config.VAL_DokterAccess && strings.ToLower(role) != config.VAL_PatientAccess && strings.ToLower(role) != config.VAL_SuperAdminAccess && strings.ToLower(role) != config.VAL_AdminAccess {
 		return []schedule.Core{}, errors.New(config.VAL_Unauthorized)
 	}
+	// if perPage <= 0 {
+	// 	perPage = 10
+	// }
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page * perPage) - perPage
+
+	if offset < 0 {
+		offset = 0
+	}
 	// log.Println("SERVICE OK")
-	res, err := ss.qry.GetAll()
+	res, err := ss.qry.GetAll(offset, perPage)
 	if err != nil {
 		return []schedule.Core{}, errors.New(err.Error())
 	}

--- a/mocks/QuestionaireData.go
+++ b/mocks/QuestionaireData.go
@@ -115,6 +115,30 @@ func (_m *QuestionaireData) CountTestAttempt(patientId string) (questionaire.Cor
 	return r0, r1, r2
 }
 
+// CountTestAttemptByFilter provides a mock function with given fields: status
+func (_m *QuestionaireData) CountTestAttemptByFilter(status string) (int64, error) {
+	ret := _m.Called(status)
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (int64, error)); ok {
+		return rf(status)
+	}
+	if rf, ok := ret.Get(0).(func(string) int64); ok {
+		r0 = rf(status)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(status)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FindAllAnswerByAttempt provides a mock function with given fields: idAttemptattempt_id, offset, limit
 func (_m *QuestionaireData) FindAllAnswerByAttempt(idAttemptattempt_id string, offset int, limit int) ([]questionaire.CoreAnswer, error) {
 	ret := _m.Called(idAttemptattempt_id, offset, limit)


### PR DESCRIPTION
fix: #135 

add pagination response at feature:
* schedule list
* booking list
* patient list
* quisioner attempt list

change logic, when client doesn't send query param limit, return all data (for select option feature on FE)