### PR TITLE
feat(150): add endpoint check codeattempt

### DIFF
--- a/app/router/router.go
+++ b/app/router/router.go
@@ -63,6 +63,7 @@ func InitRouter(db *gorm.DB, e *echo.Echo, cfg *config.AppConfig) {
 	v1Questioner.POST("/attempts/:attempt_id/assesments", sysRoute.questionaireHandler.AddAssesmentByAttempt)
 	v1Questioner.POST("", sysRoute.questionaireHandler.AddAnswer)
 	v1Questioner.POST("/validate", sysRoute.questionaireHandler.Validate)
+	v1Questioner.GET("/check", sysRoute.questionaireHandler.CheckIsValidCodeAttempt)
 
 	// users
 	v1User := v1.Group("/user")

--- a/features/questionaire/data/model.go
+++ b/features/questionaire/data/model.go
@@ -131,6 +131,7 @@ func AttempCoreToModel(core questionaire.CoreAttempt) TestAttempt {
 		ID:          core.Id,
 		PatientId:   core.PatientId,
 		CodeAttempt: core.CodeAttempt,
+		Status:      core.Status,
 	}
 }
 

--- a/features/questionaire/data/query.go
+++ b/features/questionaire/data/query.go
@@ -142,6 +142,9 @@ func (repo *questionaireQuery) CheckIsValidCodeAttempt(codeAttempt string) (isVa
 		return false, helpers.CheckQueryErrorMessage(tx.Error)
 	}
 	log.Println("len attempt data:", len(attemptData))
+	if len(attemptData) == 0 {
+		return false, errors.New("[validation] invalid code attempt. code attempt not found")
+	}
 	if len(attemptData) != 1 {
 		return false, errors.New("[validation] invalid code attempt. duplicate code attempt")
 	}

--- a/features/questionaire/entity.go
+++ b/features/questionaire/entity.go
@@ -96,4 +96,5 @@ type QuestionaireServiceInterface interface {
 	InsertAssesment(data CoreAttempt) error
 	CountQuestionerAttempt() (int, error)
 	GetPaginationTestAttempt(status string, page int, perPage int) (helpers.Pagination, error)
+	CheckIsValidCodeAttempt(codeAttempt string) (isValid bool, err error)
 }

--- a/features/questionaire/handler/handler.go
+++ b/features/questionaire/handler/handler.go
@@ -47,6 +47,21 @@ func (handler *QuestionaireHandler) Validate(c echo.Context) error {
 	return c.JSON(httpCode, mapResponse)
 }
 
+func (handler *QuestionaireHandler) CheckIsValidCodeAttempt(c echo.Context) error {
+	codeAttempt := c.QueryParam("code")
+	isValid, err := handler.questionaireService.CheckIsValidCodeAttempt(codeAttempt)
+	if err != nil {
+		jsonResponse, httpCode := helpers.WebResponseError(err, config.FEAT_QUESTIONAIRE_CODE)
+		return c.JSON(httpCode, jsonResponse)
+	}
+	data := map[string]any{}
+	if isValid {
+		data["is_valid"] = true
+	}
+	mapResponse, httpCode := helpers.WebResponseSuccess("[success] code is valid", config.FEAT_QUESTIONAIRE_CODE, data)
+	return c.JSON(httpCode, mapResponse)
+}
+
 func (handler *QuestionaireHandler) AddAnswer(c echo.Context) error {
 	answerInput := new(AnswerRequest)
 	errBind := c.Bind(&answerInput)

--- a/features/questionaire/service/logic.go
+++ b/features/questionaire/service/logic.go
@@ -78,7 +78,7 @@ func (service *questionaireService) Validate(patientData questionaire.Patient, a
 			} else {
 				go helpers.SendMailQuestionerLink(patientFound.Email, dataAttempt.CodeAttempt, service.cfg.GMAIL_APP_PASSWORD)
 			}
-			return dataAttempt.CodeAttempt, countAttempt, nil
+			return url.QueryEscape(dataAttempt.CodeAttempt), countAttempt, nil
 		}
 	} else {
 		data := patient.Core{
@@ -115,7 +115,23 @@ func (service *questionaireService) Validate(patientData questionaire.Patient, a
 		go helpers.SendMailQuestionerLink(patientData.Email, codeAttemp, service.cfg.GMAIL_APP_PASSWORD)
 	}
 
-	return codeAttemp, 0, nil
+	return url.QueryEscape(codeAttemp), 0, nil
+}
+
+// CheckIsValidCodeAttempt implements questionaire.QuestionaireServiceInterface.
+func (service *questionaireService) CheckIsValidCodeAttempt(codeAttempt string) (isValid bool, err error) {
+	// decrypt codeAttempt to idAttempt
+	if codeAttempt == "" {
+		return false, errors.New("[validation] code attempt cannot empty")
+	}
+	// codeAttemptUnescape, errUnescape := url.QueryUnescape(codeAttempt)
+	// log.Println("codeattempt", codeAttempt)
+	// log.Println("codeattemptun", codeAttemptUnescape)
+	// if errUnescape != nil {
+	// 	return false, errors.New(config.REQ_InvalidParam)
+	// }
+	isValid, err = service.questionaireData.CheckIsValidCodeAttempt(codeAttempt)
+	return
 }
 
 // InsertAnswer implements questionaire.QuestionaireServiceInterface.


### PR DESCRIPTION
Fix: #150 

* set status to `waiting` when hit endpoint `/validate` (create test attempt) 
* add endpoint `GET` `/check` with query param `code` (code attempt url escape)