### PR TITLE
feat: add pagination response on get all answers by attemptid endpoint

### DIFF
--- a/features/questionaire/data/query.go
+++ b/features/questionaire/data/query.go
@@ -35,6 +35,17 @@ func (repo *questionaireQuery) CountTestAttemptByFilter(status string) (int64, e
 	return countAttemp, nil
 }
 
+// for pagination
+// CountAllAnswersByAttemptId implements questionaire.QuestionaireDataInterface.
+func (repo *questionaireQuery) CountAllAnswersByAttemptId(idAttempt string) (int64, error) {
+	var countAnswers int64
+	tx := repo.db.Model(&Answer{}).Where("attempt_id = ? and deleted_at is null", idAttempt).Count(&countAnswers)
+	if tx.Error != nil {
+		return 0, helpers.CheckQueryErrorMessage(tx.Error)
+	}
+	return countAnswers, nil
+}
+
 // CountAllQuestion implements questionaire.QuestionaireDataInterface.
 func (repo *questionaireQuery) CountAllQuestion() (int, error) {
 	var countAttemp int64

--- a/features/questionaire/entity.go
+++ b/features/questionaire/entity.go
@@ -83,6 +83,7 @@ type QuestionaireDataInterface interface {
 	CountAllQuestion() (int, error)
 	CountQuestionerAttempt() (int, error)
 	CountTestAttemptByFilter(status string) (int64, error)
+	CountAllAnswersByAttemptId(idAttempt string) (int64, error)
 	CheckIsValidCodeAttempt(codeAttempt string) (isValid bool, err error)
 }
 
@@ -96,5 +97,6 @@ type QuestionaireServiceInterface interface {
 	InsertAssesment(data CoreAttempt) error
 	CountQuestionerAttempt() (int, error)
 	GetPaginationTestAttempt(status string, page int, perPage int) (helpers.Pagination, error)
+	GetPaginationListAnswers(idAttempt string, page int, perPage int) (helpers.Pagination, error)
 	CheckIsValidCodeAttempt(codeAttempt string) (isValid bool, err error)
 }

--- a/features/questionaire/handler/handler.go
+++ b/features/questionaire/handler/handler.go
@@ -162,6 +162,11 @@ func (handler *QuestionaireHandler) GetAllAnswerByAttempt(c echo.Context) error 
 
 	var answerResponse = ListAnswerCoreToResponse(results)
 	mapResponse, httpCode := helpers.WebResponseSuccess("[success] read data", config.FEAT_QUESTIONAIRE_CODE, answerResponse)
+	//pagination
+	paginationRes, errPagination := handler.questionaireService.GetPaginationListAnswers(idAttempt, page, limit)
+	if errPagination == nil {
+		mapResponse["pagination"] = paginationRes
+	}
 	return c.JSON(httpCode, mapResponse)
 }
 

--- a/features/questionaire/service/logic.go
+++ b/features/questionaire/service/logic.go
@@ -30,6 +30,16 @@ func (service *questionaireService) GetPaginationTestAttempt(status string, page
 	return paginationRes, nil
 }
 
+// GetPaginationListAnswers implements questionaire.QuestionaireServiceInterface.
+func (service *questionaireService) GetPaginationListAnswers(idAttempt string, page int, perPage int) (helpers.Pagination, error) {
+	totalRows, err := service.questionaireData.CountAllAnswersByAttemptId(idAttempt)
+	if err != nil {
+		return helpers.Pagination{}, err
+	}
+	paginationRes := helpers.CountPagination(totalRows, page, perPage)
+	return paginationRes, nil
+}
+
 func New(repo questionaire.QuestionaireDataInterface, patientServ patient.PatientServiceInterface, cfg *config.AppConfig) questionaire.QuestionaireServiceInterface {
 	return &questionaireService{
 		questionaireData: repo,

--- a/mocks/QuestionaireData.go
+++ b/mocks/QuestionaireData.go
@@ -60,6 +60,30 @@ func (_m *QuestionaireData) CheckIsValidCodeAttempt(codeAttempt string) (bool, e
 	return r0, r1
 }
 
+// CountAllAnswersByAttemptId provides a mock function with given fields: idAttempt
+func (_m *QuestionaireData) CountAllAnswersByAttemptId(idAttempt string) (int64, error) {
+	ret := _m.Called(idAttempt)
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (int64, error)); ok {
+		return rf(idAttempt)
+	}
+	if rf, ok := ret.Get(0).(func(string) int64); ok {
+		r0 = rf(idAttempt)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(idAttempt)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CountAllQuestion provides a mock function with given fields:
 func (_m *QuestionaireData) CountAllQuestion() (int, error) {
 	ret := _m.Called()


### PR DESCRIPTION
Fix: #152 

add pagination response on endpoint `GET` `/attempts/:attempt_id/answers`

response:
```
"pagination": {
        "page": 1,
        "limit": 5,
        "total_pages": 14,
        "total_records": 70
    }
```